### PR TITLE
Add BB tag for YouTube videos to news and forum.

### DIFF
--- a/forum.php
+++ b/forum.php
@@ -23,6 +23,7 @@ function TransformToBBCode($string) {
 		'[link={$1}]{$2}[/link]'   => '<a href="$1" target="_BLANK">$2</a>',
 		'[color={$1}]{$2}[/color]' => '<font color="$1">$2</font>',
 		'[*]{$1}[/*]' => '<li>$1</li>',
+		'[youtube]{$1}[/youtube]' => '<div class="youtube"><div class="aspectratio"><iframe src="//www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe></div></div>',
 	);
 
 	foreach ($tags as $tag => $value) {

--- a/index.php
+++ b/index.php
@@ -63,6 +63,7 @@
 					'[link={$1}]{$2}[/link]'   => '<a href="$1" target="_BLANK">$2</a>',
 					'[color={$1}]{$2}[/color]' => '<font color="$1">$2</font>',
 					'[*]{$1}[/*]' => '<li>$1</li>',
+					'[youtube]{$1}[/youtube]' => '<div class="youtube"><div class="aspectratio"><iframe src="//www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe></div></div>',
 				);
 				foreach ($tags as $tag => $value) {
 					$code = preg_replace('/placeholder([0-9]+)/', '(.*?)', preg_quote(preg_replace('/\{\$([0-9]+)\}/', 'placeholder$1', $tag), '/'));

--- a/layout/css/style.css
+++ b/layout/css/style.css
@@ -628,3 +628,25 @@ hr {
         background-color: green;
         border: 1px solid black;
 }
+
+/* ///////////\/\\\\\\\\\\\
+   //  Znote YOUTUBE BB  \\
+   ///////////\/\\\\\\\\\\\ */
+
+div.youtube {
+  width: 100%;
+  max-width: 560px;
+}
+
+div.aspectratio {
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 */
+  position: relative;
+}
+
+div.aspectratio > iframe {
+  position: absolute;
+  top: 0; bottom: 0; left: 0; right: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Usage example: [youtube]wK0w0x62PjA[/youtube]

The video frame is responsive, so that in case the width of the page is narrower than the default 560px of YouTube embed it will shrink to fit.
![screenshot from 2014-10-23 15 59 11](https://cloud.githubusercontent.com/assets/3932953/4754254/dc65968e-5abc-11e4-9044-882f64b604f9.png)

Live demo is available here: http://ot.forgee.se/index.php

If you see something you would like done differently let me know.
