### PR TITLE
Fix #188 Account activation

### DIFF
--- a/register.php
+++ b/register.php
@@ -82,7 +82,7 @@ if (empty($_POST) === false) {
 <h1>Register Account</h1>
 <?php
 if (isset($_GET['success']) && empty($_GET['success'])) {
-	if ($config['mailserver']) {
+	if ($config['mailserver']['register']) {
 		?>
 		<h1>Email authentication required</h1>
 		<p>We have sent you an email with an activation link to your submitted email address.</p>


### PR DESCRIPTION
No longer prompts users to activate account when email activation is disabled in config.