### PR TITLE
Don't display options for empty pages in highscores

### DIFF
--- a/highscores.php
+++ b/highscores.php
@@ -64,7 +64,7 @@ if ($scores) {
 		</select>
 		<select name="page">
 			<?php
-			$pages = (int)($highscore['rows'] / $highscore['rowsPerPage']);
+			$pages = ceil(min(($highscore['rows'] / $highscore['rowsPerPage']), (count($scores[$type]) / $highscore['rowsPerPage'])));
 			for ($i = 0; $i < $pages; $i++) {
 				$x = $i + 1;
 				if ($x == $page) echo "<option value='".$x."' selected>Page: ".$x."</option>";


### PR DESCRIPTION
There is no need to display options that would lead to empty pages.
This will display options for actual pages (if actual rows is less than config) or maximum rows / rowsPerPage from config whichever is less.

I did this for my site, thought I would share it if you want it.