### PR TITLE
Fixed ipn.php SQL Inserts

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -82,7 +82,7 @@
 	$custom           = (int)$_POST['custom'];
 
 	$connectedIp = $_SERVER['REMOTE_ADDR'];
-	mysql_insert("INSERT INTO `znote_paypal` VALUES ('', '$txn_id', 'Connection from IP: $connectedIp', '0', '0', '0')");
+	mysql_insert("INSERT INTO `znote_paypal` VALUES ('0', '$txn_id', 'Connection from IP: $connectedIp', '0', '0', '0')");
 	
 	$status = VerifyPaypalIPN();
 	if ($status) {
@@ -113,7 +113,7 @@
 					// Verify that the user havent messed around with POST data
 					if ($status) {
 						// transaction log
-						mysql_insert("INSERT INTO `znote_paypal` VALUES ('', '$txn_id', '$payer_email', '$custom', '".$paidMoney."', '".$paidPoints."')");
+						mysql_insert("INSERT INTO `znote_paypal` VALUES ('0', '$txn_id', '$payer_email', '$custom', '".$paidMoney."', '".$paidPoints."')");
 						
 						// Process payment
 						$data = mysql_select_single("SELECT `points` AS `old_points` FROM `znote_accounts` WHERE `account_id`='$custom';");
@@ -124,12 +124,12 @@
 					}
 				}  else {
 					$pmail = $paypal['email'];
-					mysql_insert("INSERT INTO `znote_paypal` VALUES ('', '$txn_id', 'ERROR: Wrong mail. Received: $receiver_email, configured: $pmail', '0', '0', '0')");
+					mysql_insert("INSERT INTO `znote_paypal` VALUES ('0', '$txn_id', 'ERROR: Wrong mail. Received: $receiver_email, configured: $pmail', '0', '0', '0')");
 				}
 			}
 		}
 	} else {
 		// Something is wrong
-		mysql_insert("INSERT INTO `znote_paypal` VALUES ('', '$txn_id', 'ERROR: Invalid data. $postdata', '0', '0', '0')");
+		mysql_insert("INSERT INTO `znote_paypal` VALUES ('0', '$txn_id', 'ERROR: Invalid data. $postdata', '0', '0', '0')");
 	}
 ?>


### PR DESCRIPTION
I don't know what version of TFS I'm using, but the ipn.php wasn't inserting any row to the znote_paypal table after completing the donation, consequently, even if the purchase was successful, no points were added to the donator. 

Everything started working when I changed the SQL inserts located at the ipn.php file, and forced the 'id' column to auto-increment.

http://stackoverflow.com/questions/14762904/incorrect-integer-value-for-column-id-at-row-1