### PR TITLE
Changed znote_accounts ip row to UNSIGNED

### DIFF
--- a/engine/database/connect.php
+++ b/engine/database/connect.php
@@ -38,7 +38,7 @@ INSERT INTO `znote` (`version`, `installed`) VALUES
 CREATE TABLE IF NOT EXISTS `znote_accounts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `account_id` int(11) NOT NULL,
-  `ip` int(10) NOT NULL,
+  `ip` int(10) UNSIGNED NOT NULL,
   `created` int(10) NOT NULL,
   `points` int(10) DEFAULT 0,
   `cooldown` int(10) DEFAULT 0,


### PR DESCRIPTION
I found that I'm using TFS 1.3, and everytime I created an account using the Znote AAC, a message appeared: znote_account ip row: out of range. So I changed it to UNSIGNED, and now the messages are gone.