### PR TITLE
Switching keys' places (fits Google order)

### DIFF
--- a/config.php
+++ b/config.php
@@ -777,8 +777,8 @@
 	$config['use_token'] = false;
 	// Set up captcha keys on https://www.google.com/recaptcha/
 	$config['use_captcha'] = false;
-	$config['captcha_secret_key'] = "Secret key";
 	$config['captcha_site_key'] = "Site key";
+	$config['captcha_secret_key'] = "Secret key";
 
 	// Session prefix, if you are hosting multiple sites, make the session name different to avoid conflict.
 	$config['session_prefix'] = 'znote_';


### PR DESCRIPTION
It's just to fit Google order on website:

![Loading image](http://i.imgur.com/WBDosHh.jpg)