### PR TITLE
login.php error return header 401

### DIFF
--- a/login.php
+++ b/login.php
@@ -209,6 +209,7 @@ if (empty($errors) === false) {
 	?>
 	<h2>We tried to log you in, but...</h2>
 	<?php
+	header("HTTP/1.1 401 Not Found");
 	echo output_errors($errors);
 }
 


### PR DESCRIPTION
Now invalid credits in login form produce **401** status code in logs.
401 Unauthorized (RFC 7235) https://en.wikipedia.org/wiki/List_of_HTTP_status_codes

It helps configure fail2ban to protect ZnoteAcc against brute force attacks.

At this moment failed login attemt looks like:
```
127.0.0.1 - - [16/Jul/2017:09:06:05 +0000] "POST /login.php HTTP/1.1" 401 2146 "https://example.com/login.php" "Mozilla/5.0_my_client_options_etc"
```

Same as I suggested here: https://github.com/Znote/ZnoteAAC/issues/301