### PR TITLE
Paygol IPN update

### DIFF
--- a/config.php
+++ b/config.php
@@ -880,10 +880,11 @@
 	// to you 1 month after recieving 50+ eur.
 	$config['paygol'] = array(
 		'enabled' => false,
-		'serviceID' => 86648,// Service ID from paygol.com
+		'serviceID' => 86648, // Service ID from paygol.com
+		'secretKey' => 'xxxx-xxxx-xxxx-xxxx', // Secret key from paygol.com. Never share your secret key
 		'currency' => 'SEK',
 		'price' => 20,
-		'points' => 20, // Remember to write same details in paygol.com!
+		'points' => 20,
 		'name' => '20 points',
 		'returnURL' => "http://".$_SERVER['HTTP_HOST']."/success.php",
 		'cancelURL' => "http://".$_SERVER['HTTP_HOST']."/failed.php"

--- a/paygol_ipn.php
+++ b/paygol_ipn.php
@@ -2,13 +2,6 @@
 require 'config.php';
 require 'engine/database/connect.php';
 
-// check that the request comes from PayGol server
-if(!in_array($_SERVER['REMOTE_ADDR'],
-	array('109.70.3.48', '109.70.3.146', '109.70.3.58'))) {
-	header("HTTP/1.0 403 Forbidden");
-	die("Error: Unknown IP");
-}
-
 // Fetch and sanitize POST and GET values
 function getValue($value) {
 	return (!empty($value)) ? sanitize($value) : false;
@@ -30,9 +23,16 @@ $custom	 = getValue($_GET['custom']);
 $points	 = getValue($_GET['points']);
 $price	 = getValue($_GET['price']);
 $currency	= getValue($_GET['currency']);
+$secret = getValue($_GET['secret']);
 
 // config paygol settings
 $paygol = $config['paygol'];
+
+// Check for valid secret key
+if($secret != $paygol['secret']) {
+	header("HTTP/1.0 403 Forbidden");
+	die("Error: secretKey does not match.");
+}
 
 // Check if request serviceID is the same as it is in config
 if($service_id != $paygol['serviceID']) {
@@ -41,12 +41,15 @@ if($service_id != $paygol['serviceID']) {
 }
 
 $new_points = $paygol['points'];
+
 // Update logs:
 mysql_insert("INSERT INTO `znote_paygol` VALUES ('', '$custom', '$price', '$new_points', '$message_id', '$service_id', '$shortcode', '$keyword', '$message', '$sender', '$operator', '$country', '$currency')");
+
 // Fetch points
 $account = mysql_select_single("SELECT `points` FROM `znote_accounts` WHERE `account_id`='$custom';");
+
 // Calculate new points
 $new_points = $account['points'] + $new_points;
+
 // Update new points
 mysql_update("UPDATE `znote_accounts` SET `points`='$new_points' WHERE `account_id`='$custom'");
-?>

--- a/paygol_ipn.php
+++ b/paygol_ipn.php
@@ -16,14 +16,14 @@ $service_id	= getValue($_GET['service_id']);
 $shortcode	= getValue($_GET['shortcode']);
 $keyword	= getValue($_GET['keyword']);
 $message	= getValue($_GET['message']);
-$sender	 = getValue($_GET['sender']);
+$sender	    = getValue($_GET['sender']);
 $operator	= getValue($_GET['operator']);
 $country	= getValue($_GET['country']);
-$custom	 = getValue($_GET['custom']);
-$points	 = getValue($_GET['points']);
-$price	 = getValue($_GET['price']);
+$custom	    = getValue($_GET['custom']);
+$points	    = getValue($_GET['points']);
+$price	    = getValue($_GET['price']);
 $currency	= getValue($_GET['currency']);
-$secret = getValue($_GET['secret']);
+$secret     = getValue($_GET['secret']);
 
 // config paygol settings
 $paygol = $config['paygol'];

--- a/paygol_ipn.php
+++ b/paygol_ipn.php
@@ -16,14 +16,14 @@ $service_id	= getValue($_GET['service_id']);
 $shortcode	= getValue($_GET['shortcode']);
 $keyword	= getValue($_GET['keyword']);
 $message	= getValue($_GET['message']);
-$sender	    = getValue($_GET['sender']);
+$sender		= getValue($_GET['sender']);
 $operator	= getValue($_GET['operator']);
 $country	= getValue($_GET['country']);
-$custom	    = getValue($_GET['custom']);
-$points	    = getValue($_GET['points']);
-$price	    = getValue($_GET['price']);
+$custom		= getValue($_GET['custom']);
+$points		= getValue($_GET['points']);
+$price		= getValue($_GET['price']);
 $currency	= getValue($_GET['currency']);
-$secret     = getValue($_GET['secret']);
+$secret		= getValue($_GET['secret']);
 
 // config paygol settings
 $paygol = $config['paygol'];


### PR DESCRIPTION
Paygol now uses a secret key, we dont need to check for remote address anymore, also, prices are now not linked to services, this means you can use the price you want and change at anytime

This PR adds the secret key to the `config.php` file and checks for the value at `paygol_ipn.php` and might fix issue #296 