### PR TITLE
Added information regarding downloading master branch of PHPMailer

### DIFF
--- a/config.php
+++ b/config.php
@@ -669,7 +669,9 @@
 	);
 
 	// Email Server configurations (SMTP)
-	/* Download PHPMailer: https://github.com/PHPMailer/PHPMailer/archive/master.zip
+
+	/*	Please consider using a released stable version of PHPMailer or you may run into issues, such as 6.0.1.
+		Download PHPMailer: https://github.com/PHPMailer/PHPMailer/
 		Extract to Znote AAC directory (where this config.php file is located)
 		Rename the folder to "PHPMailer". Then configure this with your SMTP mail settings from your email provider.
 	*/

--- a/config.php
+++ b/config.php
@@ -669,7 +669,6 @@
 	);
 
 	// Email Server configurations (SMTP)
-
 	/*	Please consider using a released stable version of PHPMailer or you may run into issues, such as 6.0.1.
 		Download PHPMailer: https://github.com/PHPMailer/PHPMailer/
 		Extract to Znote AAC directory (where this config.php file is located)


### PR DESCRIPTION
Added information regarding downloading master branch of PHPMailer, due to that master branch is currently broken, and will throw HTTP error code 500 at account recovery and account registration if e-mail verification is enabled.