### PR TITLE
Tibia client 11.49.5921 support

### DIFF
--- a/login.php
+++ b/login.php
@@ -55,6 +55,7 @@ if($_SERVER['HTTP_USER_AGENT'] == "Mozilla/5.0" && $config['TFSVersion'] === 'TF
 			$response = array(
 				'session' => array(
 					'fpstracking' => false,
+					'optiontracking' => false,
 					'isreturner' => true,
 					'returnernotification' => false,
 					'showrewardnews' => false,
@@ -75,6 +76,8 @@ if($_SERVER['HTTP_USER_AGENT'] == "Mozilla/5.0" && $config['TFSVersion'] === 'TF
 							'location' => 'ALL',
 							'externaladdressunprotected' => $gameserver['ip'],
 							'externaladdressprotected' => $gameserver['ip'],
+							'externalportunprotected' => $gameserver['port'],
+							'externalportprotected' => $gameserver['port'],
 							'anticheatprotection' => false
 						)
 					),


### PR DESCRIPTION
Adds additional login-session-data that was introduced in the Tibia 11.49.5921 client update. This is current as of the Tibia 11.75 client version.

@Znote I didn't add it to this PR, but if you want to add support for the new counters for online players and twitch/youtube streams/viewers (that the current client displays) the client sends
```json
{
    "type":"cacheinfo"
}
```
to the login webservice, and expects to receive
```json
{
    "playersonline":1234,
    "twitchstreams":1234,
    "twitchviewer":1234,
    "gamingyoutubestreams":1234,
    "gamingyoutubeviewer":1234
}
```