### PR TITLE
Fixing username recovery in recovery.php

### DIFF
--- a/recovery.php
+++ b/recovery.php
@@ -164,7 +164,7 @@ if ($config['mailserver']['accountRecovery']) {
 					
 					if ($mode === 'password') {
 						echo '<label for="username">Username:</label> <input type="text" name="username"><br>';
-					} elseif ($mode === 'password') {
+					} elseif ($mode === 'username') {
 						echo '<label for="password">Password:</label> <input type="password" name="password"><br>';
 					} elseif ($mode === 'token') {
 						echo '<label for="username">Username:</label> <input type="text" name="username"><br>';


### PR DESCRIPTION
When trying to recover username, the password input wouldn't show.