### PR TITLE
better $postdata encoding

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -65,13 +65,10 @@
 	header('HTTP/1.1 200 OK'); 
 
 	// Build the required acknowledgement message out of the notification just received
-	$req = 'cmd=_notify-validate';
-	foreach ($_POST as $key => $value) {
-		$value = urlencode(stripslashes($value));
-		$req  .= "&$key=$value";
+	$postdata = 'cmd=_notify-validate';
+	if(!empty($_POST)){
+		$postdata.="&".http_build_query($_POST);
 	}
-	$postdata = $req;
-	
 	// Assign payment notification values to local variables
 	$item_name        = $_POST['item_name'];
 	$item_number      = $_POST['item_number'];


### PR DESCRIPTION
idk what stripslashes() was doing in there, but it was definitely a bug (there's no way the slashes in there, if any, had no purpose and could just be discarded.. right?)

in addition, post data with keys containing special characters (if any) was incorrectly encoded. a correct encoding loop goes like:

foreach ($_POST as $key => $value) {
	$req.="&".urlencode($key)."=".urlencode($value);
}
but the original code was only encoding the value, not the key... but even better than a custom encoding loop is to just use http_build_query(), which does the entire encoding loop for us :) so that's what i changed it to.