### PR TITLE
Fix for wrong mana, correct is 90 and not 40

### DIFF
--- a/config.php
+++ b/config.php
@@ -446,7 +446,7 @@
 		'base' => array(
 			'level' => 8,
 			'health' => 185,
-			'mana' => 40,
+			'mana' => 90,
 			'cap' => 470,
 			'soul' => 100
 		),


### PR DESCRIPTION
Fix https://github.com/Znote/ZnoteAAC/issues/405
In update 10.50 ~~ more or less, the base mana increased by 55 points. (the correct would be 35)

As a suggestion, I would say it would be interesting to put the server name directly from config.lua.
Or, in the install, create a "config.local.php" such as myaac and download for internal use of the website.
At OTServBR-Global, we come across many people having difficulties with these settings that need to be the same.
https://github.com/Znote/ZnoteAAC/blob/bb60bfbf8355e931d0436ef2382a83380fe8efe1/config.php#L646