### PR TITLE
Set password limit to 29 characters

### DIFF
--- a/register.php
+++ b/register.php
@@ -65,18 +65,8 @@ if (empty($_POST) === false) {
 		if (strlen($_POST['password']) < 6) {
 			$errors[] = 'Your password must be at least 6 characters.';
 		}
-		if($config['client'] >= 1200) {
-			if (strlen($_POST['password']) > 100) {
-				// client 12.x accepts more than 200 characters
-				// don't know the exact value, but lets limit it to 100 characters as it was before
-				$errors[] = 'Your password must be less than 100 characters.';
-			}
-		}
-		else {
-			if (strlen($_POST['password']) > 29) {
-				// older client accepts 29 characters
-				$errors[] = 'Your password must be less than 30 characters.';
-			}
+		if (strlen($_POST['password']) > 29) {
+			$errors[] = 'Your password must be less than 30 characters.';
 		}
 		if ($_POST['password'] !== $_POST['password_again']) {
 			$errors[] = 'Your passwords do not match.';

--- a/register.php
+++ b/register.php
@@ -65,8 +65,18 @@ if (empty($_POST) === false) {
 		if (strlen($_POST['password']) < 6) {
 			$errors[] = 'Your password must be at least 6 characters.';
 		}
-		if (strlen($_POST['password']) > 100) {
-			$errors[] = 'Your password must be less than 100 characters.';
+		if($config['client'] >= 1200) {
+			if (strlen($_POST['password']) > 100) {
+				// client 12.x accepts more than 200 characters
+				// don't know the exact value, but lets limit it to 100 characters as it was before
+				$errors[] = 'Your password must be less than 100 characters.';
+			}
+		}
+		else {
+			if (strlen($_POST['password']) > 29) {
+				// older client accepts 29 characters
+				$errors[] = 'Your password must be less than 30 characters.';
+			}
 		}
 		if ($_POST['password'] !== $_POST['password_again']) {
 			$errors[] = 'Your passwords do not match.';


### PR DESCRIPTION
So, like we talked on Discord, this commit sets limit for the password.

Older clients accept 29 characters.

12.x clients accept more than 200 characters, but I leaved it unchanged as it was previously (100 characters).

Up to you what you decide, but I think 100 characters is reasonable.

#Edit
Ok seems I was wrong.
After tests the real limit seems to be 29 characters, also on newest client.