### PR TITLE
TFS compability adjustments to webLogin

### DIFF
--- a/login.php
+++ b/login.php
@@ -213,8 +213,9 @@ if($_SERVER['HTTP_USER_AGENT'] == "Mozilla/5.0" && $config['ServerEngine'] === '
 				}
 
 				$sessionKey = ($email !== false) ? $email."\n".$client->password : $username."\n".$client->password;
-				if (isset($account['secret']) && strlen($account['secret']) > 5) $sessionKey .= "\n".$token."\n".floor(time() / 30);
-
+				$sessionKey .= (isset($account['secret']) && strlen($account['secret']) > 5) ? "\n".$token : "\n";
+				$sessionKey .= "\n".floor(time() / 30);
+				
 				$response = array(
 					'session' => array(
 						'fpstracking' => false,


### PR DESCRIPTION
### Proposed change
This commit makes client 12 send the same login packet as 10.98 client.
It will fix an issue with game world auth failing in otland TFS when token and timestamp fields are missing.

This change is experimental and is meant for when version 12 support will be ready in clean TFS.
I haven't tested if Canary and otbr global are ok with two extra fields in packet as they don't use token for game world auth.
For context see: https://github.com/otland/forgottenserver/pull/3671