### PR TITLE
Fix Undefined array key "HTTP_USER_AGENT" in PHP 8.1

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?php if($_SERVER['HTTP_USER_AGENT'] == "Mozilla/5.0") { require_once 'login.php'; die(); } // Client 11 loginWebService
+<?php if(isset($_SERVER["HTTP_USER_AGENT"]) && $_SERVER['HTTP_USER_AGENT'] == "Mozilla/5.0") { require_once 'login.php'; die(); } // Client 11 loginWebService
 require_once 'engine/init.php'; include 'layout/overall/header.php';
 
 	if (!isset($_GET['page'])) {


### PR DESCRIPTION
FastCGI sent in stderr: "PHP message: PHP Warning:  Undefined array key "HTTP_USER_AGENT" in /home/www/index.php on line 4" while reading response header from upstream, client: xxx, server: xxx.com, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/php/php8.1-fpm.sock:", host: "xxx"
